### PR TITLE
Add event creation feature test

### DIFF
--- a/tests/Feature/EventCreationTest.php
+++ b/tests/Feature/EventCreationTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Evenement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventCreationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_organisateur_can_create_event(): void
+    {
+        $user = User::factory()->create(['role' => 'organisateur']);
+
+        $data = [
+            'titre' => 'Test Event',
+            'description' => 'Une description',
+            'date' => '2025-06-30',
+            'lieu' => 'Paris',
+        ];
+
+        $response = $this->actingAs($user)->post('/evenements', $data);
+
+        $response->assertRedirect(route('evenements.index', absolute: false));
+        $response->assertSessionHas('success', 'Événement créé.');
+
+        $this->assertDatabaseHas('evenements', $data + ['organisateur_id' => $user->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- add feature test for creating events

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400158aec883339b6305d1d4c55ac6